### PR TITLE
Remove a duplicate dollar sign in the price command

### DIFF
--- a/src/CoinBot.Discord/Commands/PriceCommands.cs
+++ b/src/CoinBot.Discord/Commands/PriceCommands.cs
@@ -31,7 +31,7 @@ namespace CoinBot.Discord.Commands
 					if (currency != null)
 					{
 						CoinMarketCapCoin details = currency.Getdetails<CoinMarketCapCoin>();
-						await this.ReplyAsync($"{currency.Symbol} - ${details.GetPriceSummary()} ({details.GetChangeSummary()})");
+						await this.ReplyAsync($"{currency.Symbol} - {details.GetPriceSummary()} ({details.GetChangeSummary()})");
 					}
 					else
 					{


### PR DESCRIPTION
The dollar sign is already in the response of the GetPriceSummary method.