### PR TITLE
Add the !events command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,24 @@ Discord Cryptocurrency Bot
 
 3. Application configuration settings:
   * `DiscordBot:Token` [Required] Must be configured with the Discord Bot User Token.
+  * `CoinMarketCal:ClientId` [Required] Must be configured with the [CoinMarketCal](https://api.coinmarketcal.com/developer/register) Client Id.
+  * `CoinMarketCal:ClientSecret` [Required] Must be configured with the [CoinMarketCal](https://api.coinmarketcal.com/developer/register) Client Secret.
   * `MarketManager:RefreshInterval` [Optional] The exchange refresh interval in minutes. Default is `2` minutes.
 
 
 4. Choose how you want to configure the application:
   * Create a file named `appsettings.json` inside the `CoinBot` project and add the following contents: 
- ```json0
+ ```json
 {
   "DiscordBot": {
     "Token": "[Discord Bot User Token goes here]"
   },
   "MarketManager": {
     "RefreshInterval": 2
+  },
+  "CoinMarketCal": {
+    "ClientId": "[CoinMarketCal Client ID goes here]",
+    "ClientSecret": "[CoinMarketCal Client Secret goes here]"
   }
 }
 ```

--- a/src/CoinBot.Clients/CoinMarketCal/CoinDto.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinDto.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace CoinBot.Clients.CoinMarketCal
+{
+	public class CoinDto
+	{
+		[JsonProperty("id", Required = Required.Always)]
+		public string Id { get; set; }
+
+		[JsonProperty("name", Required = Required.Always)]
+		public string Name { get; set; }
+
+		[JsonProperty("symbol", Required = Required.Always)]
+		public string Symbol { get; set; }
+	}
+}

--- a/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
@@ -88,11 +88,11 @@ namespace CoinBot.Clients.CoinMarketCal
 					{
 						Title = e.Title,
 						Description = e.Description,
-						Currency = this._currencyManager.Get(e.CoinSymbol),
+						Currency = currency,
 						Date = e.DateEvent,
 						ProofSource = e.Source != null ? new Uri(e.Source) : null,
 						ProofImage = e.Proof != null ? new Uri(e.Proof) : null,
-						IsDeadline = e.EventIsDeadline,
+						CanOccurBefore = e.CanOccurBefore,
 						Reliability = e.Percentage
 					}).ToList();
 

--- a/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web;
 using CoinBot.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace CoinBot.Clients.CoinMarketCal
@@ -15,17 +17,17 @@ namespace CoinBot.Clients.CoinMarketCal
 		/// <summary>
 		/// The <see cref="Uri"/> of the CoinMarketCal endpoint.
 		/// </summary>
-		private readonly Uri _baseUri = new Uri("https://coinmarketcal.com/api/", UriKind.Absolute);
+		private readonly Uri _baseUri = new Uri("https://api.coinmarketcal.com/", UriKind.Absolute);
 
 		/// <summary>
-		/// The <see cref="CurrencyManager"/>.
+		/// The <see cref="Uri"/> of the CoinMarketCal coins endpoint.
 		/// </summary>
-		private readonly CurrencyManager _currencyManager;
+		private readonly Uri _coinsUri = new Uri("v1/coins", UriKind.Relative);
 
 		/// <summary>
-		/// The <see cref="Uri"/> of the CoinMarketCal endpoint.
+		/// The <see cref="Uri"/> of the CoinMarketCal events endpoint.
 		/// </summary>
-		private readonly Uri _eventsUri = new Uri("events", UriKind.Relative);
+		private readonly Uri _eventsUri = new Uri("v1/events", UriKind.Relative);
 
 		/// <summary>
 		/// The <see cref="HttpClient"/>.
@@ -43,14 +45,38 @@ namespace CoinBot.Clients.CoinMarketCal
 		private readonly JsonSerializerSettings _serializerSettings;
 
 		/// <summary>
+		/// The <see cref="CoinMarketCalSettings"/>.
+		/// </summary>
+		private readonly CoinMarketCalSettings _settings;
+
+		/// <summary>
+		/// The <see cref="Uri"/> of the CoinMarketCal oauth endpoint.
+		/// </summary>
+		private readonly Uri _tokenUri = new Uri("oauth/v2/token", UriKind.Relative);
+
+		/// <summary>
+		/// All the coins.
+		/// </summary>
+		private IEnumerable<CoinDto> _coins;
+
+		/// <summary>
+		/// The CoinMarketCal token.
+		/// </summary>
+		private string _token;
+
+		/// <summary>
+		/// The <see cref="DateTime"/> when the <see cref="_token"/> expires.
+		/// </summary>
+		private DateTime _tokenExpires;
+
+		/// <summary>
 		/// Constructs an <see cref="CoinMarketCalClient"/>.
 		/// </summary>
-		/// <param name="currencyManager"></param>
 		/// <param name="logger"></param>
-		public CoinMarketCalClient(CurrencyManager currencyManager, ILogger logger)
+		public CoinMarketCalClient(ILogger logger, IOptions<CoinMarketCalSettings> settings)
 		{
-			this._currencyManager = currencyManager ?? throw new ArgumentNullException(nameof(currencyManager));
 			this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this._settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
 			this._httpClient = new HttpClient
 			{
 				BaseAddress = this._baseUri
@@ -72,12 +98,24 @@ namespace CoinBot.Clients.CoinMarketCal
 		/// <returns></returns>
 		public async Task<EventsDto> GetEvents(Currency currency)
 		{
+			if (DateTime.Now > this._tokenExpires)
+				await this.RenewAccessToken();
+
+			// TODO: Interval update
+			if (this._coins == null)
+				this._coins = await this.GetCoins();
+
 			const int max = 5;
+			var coin = this._coins.SingleOrDefault(c => c.Symbol.Equals(currency.Symbol, StringComparison.OrdinalIgnoreCase));
+			if (coin == null)
+				return null;
+
 			var uriBuilder = new UriBuilder(new Uri(this._baseUri, this._eventsUri));
 			var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+			query["access_token"] = this._token;
 			query["showPastEvent"] = "false";
 			query["max"] = max.ToString();
-			query["coins"] = $"{currency.Name} ({currency.Symbol})";
+			query["coins"] = $"{coin.Id}";
 			uriBuilder.Query = query.ToString();
 
 			using (var response = await this._httpClient.GetAsync(uriBuilder.Uri))
@@ -101,6 +139,53 @@ namespace CoinBot.Clients.CoinMarketCal
 					LastUpdated = DateTime.Now,
 					Events = events
 				};
+			}
+		}
+
+		public async Task Initialize()
+		{
+			await this.RenewAccessToken();
+			this._coins = await this.GetCoins();
+		}
+
+		/// <summary>
+		/// Gets an access token.
+		/// </summary>
+		/// <returns></returns>
+		private async Task RenewAccessToken()
+		{
+			var uriBuilder = new UriBuilder(new Uri(this._baseUri, this._tokenUri));
+			var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+			query["grant_type"] = "client_credentials";
+			query["client_id"] = this._settings.ClientId;
+			query["client_secret"] = this._settings.ClientSecret;
+			uriBuilder.Query = query.ToString();
+
+			using (var response = await this._httpClient.GetAsync(uriBuilder.Uri))
+			{
+				string json = await response.Content.ReadAsStringAsync();
+				TokenResponseDto tokenResult = JsonConvert.DeserializeObject<TokenResponseDto>(json, this._serializerSettings);
+				this._token = tokenResult.AccessToken;
+				this._tokenExpires = DateTime.Now.AddSeconds(tokenResult.ExpiresIn);
+			}
+		}
+
+		/// <summary>
+		/// Gets all the coins.
+		/// </summary>
+		/// <returns></returns>
+		private async Task<IEnumerable<CoinDto>> GetCoins()
+		{
+			var uriBuilder = new UriBuilder(new Uri(this._baseUri, this._coinsUri));
+			var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+			query["access_token"] = this._token;
+			uriBuilder.Query = query.ToString();
+
+			using (var response = await this._httpClient.GetAsync(uriBuilder.Uri))
+			{
+				string json = await response.Content.ReadAsStringAsync();
+				IEnumerable<CoinDto> coins = JsonConvert.DeserializeObject<IEnumerable<CoinDto>>(json, this._serializerSettings);
+				return coins;
 			}
 		}
 	}

--- a/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalClient.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using CoinBot.Core;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace CoinBot.Clients.CoinMarketCal
+{
+	public class CoinMarketCalClient : IEventClient
+	{
+		/// <summary>
+		/// The <see cref="Uri"/> of the CoinMarketCal endpoint.
+		/// </summary>
+		private readonly Uri _baseUri = new Uri("https://coinmarketcal.com/api/", UriKind.Absolute);
+
+		/// <summary>
+		/// The <see cref="CurrencyManager"/>.
+		/// </summary>
+		private readonly CurrencyManager _currencyManager;
+
+		/// <summary>
+		/// The <see cref="Uri"/> of the CoinMarketCal endpoint.
+		/// </summary>
+		private readonly Uri _eventsUri = new Uri("events", UriKind.Relative);
+
+		/// <summary>
+		/// The <see cref="HttpClient"/>.
+		/// </summary>
+		private readonly HttpClient _httpClient;
+
+		/// <summary>
+		/// The <see cref="ILogger"/>.
+		/// </summary>
+		private readonly ILogger _logger;
+
+		/// <summary>
+		/// The <see cref="JsonSerializerSettings"/>.
+		/// </summary>
+		private readonly JsonSerializerSettings _serializerSettings;
+
+		/// <summary>
+		/// Constructs an <see cref="CoinMarketCalClient"/>.
+		/// </summary>
+		/// <param name="currencyManager"></param>
+		/// <param name="logger"></param>
+		public CoinMarketCalClient(CurrencyManager currencyManager, ILogger logger)
+		{
+			this._currencyManager = currencyManager ?? throw new ArgumentNullException(nameof(currencyManager));
+			this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this._httpClient = new HttpClient
+			{
+				BaseAddress = this._baseUri
+			};
+
+			this._serializerSettings = new JsonSerializerSettings
+			{
+				Error = (sender, args) =>
+				{
+					var ex = args.ErrorContext.Error.GetBaseException();
+					this._logger.LogError(new EventId(args.ErrorContext.Error.HResult), ex, ex.Message);
+				}
+			};
+		}
+
+		/// <summary>
+		/// Get events for a given <see cref="Currency"/>.
+		/// </summary>
+		/// <returns></returns>
+		public async Task<EventsDto> GetEvents(Currency currency)
+		{
+			const int max = 5;
+			var uriBuilder = new UriBuilder(new Uri(this._baseUri, this._eventsUri));
+			var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+			query["showPastEvent"] = "false";
+			query["max"] = max.ToString();
+			query["coins"] = $"{currency.Name} ({currency.Symbol})";
+			uriBuilder.Query = query.ToString();
+
+			using (var response = await this._httpClient.GetAsync(uriBuilder.Uri))
+			{
+				string json = await response.Content.ReadAsStringAsync();
+				List<EventDto> events = JsonConvert.DeserializeObject<List<CoinMarketCalEventDto>>(json, this._serializerSettings)
+					.Select(e => new EventDto
+					{
+						Title = e.Title,
+						Description = e.Description,
+						Currency = this._currencyManager.Get(e.CoinSymbol),
+						Date = e.DateEvent,
+						ProofSource = e.Source != null ? new Uri(e.Source) : null,
+						ProofImage = e.Proof != null ? new Uri(e.Proof) : null,
+						IsDeadline = e.EventIsDeadline,
+						Reliability = e.Percentage
+					}).ToList();
+
+				return new EventsDto
+				{
+					LastUpdated = DateTime.Now,
+					Events = events
+				};
+			}
+		}
+	}
+}

--- a/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalEventDto.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalEventDto.cs
@@ -13,12 +13,6 @@ namespace CoinBot.Clients.CoinMarketCal
 		[JsonProperty("title", Required = Required.Always)]
 		public string Title { get; set; }
 
-		[JsonProperty("coin_name", Required = Required.Always)]
-		public string CoinName { get; set; }
-
-		[JsonProperty("coin_symbol", Required = Required.Always)]
-		public string CoinSymbol { get; set; }
-
 		[JsonProperty("date_event", Required = Required.Always)]
 		public DateTime DateEvent { get; set; }
 
@@ -46,19 +40,7 @@ namespace CoinBot.Clients.CoinMarketCal
 		[JsonProperty("percentage", Required = Required.Always)]
 		public int Percentage { get; set; }
 
-		[JsonProperty("categories", Required = Required.Always)]
-		public List<string> Categories { get; set; }
-
-		[JsonProperty("tip_symbol", Required = Required.Default)]
-		public string TipSymbol { get; set; }
-
-		[JsonProperty("tip_adress", Required = Required.Default)]
-		public string TipAdress { get; set; }
-
-		[JsonProperty("twitter_account", Required = Required.Default)]
-		public string TwitterAccount { get; set; }
-
-		[JsonProperty("event_is_deadline", Required = Required.Always)]
-		public bool EventIsDeadline { get; set; }
+		[JsonProperty("can_occur_before", Required = Required.Always)]
+		public bool CanOccurBefore { get; set; }
 	}
 }

--- a/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalEventDto.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/CoinMarketCalEventDto.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CoinBot.Clients.CoinMarketCal
+{
+	[JsonObject]
+	internal sealed class CoinMarketCalEventDto
+	{
+		[JsonProperty("id", Required = Required.Always)]
+		public int Id { get; set; }
+
+		[JsonProperty("title", Required = Required.Always)]
+		public string Title { get; set; }
+
+		[JsonProperty("coin_name", Required = Required.Always)]
+		public string CoinName { get; set; }
+
+		[JsonProperty("coin_symbol", Required = Required.Always)]
+		public string CoinSymbol { get; set; }
+
+		[JsonProperty("date_event", Required = Required.Always)]
+		public DateTime DateEvent { get; set; }
+
+		[JsonProperty("created_date", Required = Required.Always)]
+		public DateTime CreatedDate { get; set; }
+
+		[JsonProperty("description", Required = Required.Always)]
+		public string Description { get; set; }
+
+		[JsonProperty("proof", Required = Required.Always)]
+		public string Proof { get; set; }
+
+		[JsonProperty("source", Required = Required.Default)]
+		public string Source { get; set; }
+
+		[JsonProperty("is_hot", Required = Required.Always)]
+		public bool IsHot { get; set; }
+
+		[JsonProperty("vote_count", Required = Required.Always)]
+		public int VoteCount { get; set; }
+
+		[JsonProperty("positive_vote_count", Required = Required.Always)]
+		public int PositiveVoteCount { get; set; }
+
+		[JsonProperty("percentage", Required = Required.Always)]
+		public int Percentage { get; set; }
+
+		[JsonProperty("categories", Required = Required.Always)]
+		public List<string> Categories { get; set; }
+
+		[JsonProperty("tip_symbol", Required = Required.Default)]
+		public string TipSymbol { get; set; }
+
+		[JsonProperty("tip_adress", Required = Required.Default)]
+		public string TipAdress { get; set; }
+
+		[JsonProperty("twitter_account", Required = Required.Default)]
+		public string TwitterAccount { get; set; }
+
+		[JsonProperty("event_is_deadline", Required = Required.Always)]
+		public bool EventIsDeadline { get; set; }
+	}
+}

--- a/src/CoinBot.Clients/CoinMarketCal/TokenResponseDto.cs
+++ b/src/CoinBot.Clients/CoinMarketCal/TokenResponseDto.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace CoinBot.Clients.CoinMarketCal
+{
+	public class TokenResponseDto
+	{
+		[JsonProperty("access_token", Required = Required.Always)]
+		public string AccessToken { get; set; }
+
+		[JsonProperty("expires_in", Required = Required.Always)]
+		public int ExpiresIn { get; set; }
+
+		[JsonProperty("scope", Required = Required.Default)]
+		public object Scope { get; set; }
+
+		[JsonProperty("token_type", Required = Required.Always)]
+		public string TokenType { get; set; }
+	}
+}

--- a/src/CoinBot.Clients/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CoinBot.Clients/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using CoinBot.Clients.Binance;
 using CoinBot.Clients.Bittrex;
+using CoinBot.Clients.CoinMarketCal;
 using CoinBot.Clients.CoinMarketCap;
 using CoinBot.Clients.GateIo;
 using CoinBot.Clients.Gdax;
@@ -31,7 +32,8 @@ namespace CoinBot.Clients.Extensions
 				.AddSingleton<IMarketClient, GateIoClient>()
 				.AddSingleton<IMarketClient, KrakenClient>()
 				.AddSingleton<IMarketClient, LiquiClient>()
-				.AddSingleton<IMarketClient, PoloniexClient>();
+				.AddSingleton<IMarketClient, PoloniexClient>()
+				.AddSingleton<IEventClient, CoinMarketCalClient>();
 		}
 	}
 }

--- a/src/CoinBot.Core/CoinBot.Core.csproj
+++ b/src/CoinBot.Core/CoinBot.Core.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/src/CoinBot.Core/CoinMarketCalSettings.cs
+++ b/src/CoinBot.Core/CoinMarketCalSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace CoinBot.Core
+{
+	/// <summary>
+	/// https://api.coinmarketcal.com/
+	/// </summary>
+	public class CoinMarketCalSettings
+	{
+		/// <summary>
+		/// The client id.
+		/// </summary>
+		public string ClientId { get; set; }
+
+		/// <summary>
+		/// The client secret.
+		/// </summary>
+		public string ClientSecret { get; set; }
+	}
+}

--- a/src/CoinBot.Core/EventDto.cs
+++ b/src/CoinBot.Core/EventDto.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace CoinBot.Core
+{
+	public sealed class EventDto
+	{
+		/// <summary>
+		/// A percentage indicating the reliability / accuracy of the event.
+		/// </summary>
+		public int Reliability { get; set; }
+
+		/// <summary>
+		/// The <see cref="Currency"/> the event is for.
+		/// </summary>
+		public Currency Currency { get; set; }
+
+		/// <summary>
+		/// The <see cref="DateTime"/> of the event.
+		/// </summary>
+		public DateTime Date { get; set; }
+
+		/// <summary>
+		/// The event description.
+		/// </summary>
+		public string Description { get; set; }
+
+		/// <summary>
+		/// If true, the <see cref="Date"/> is a deadline.
+		/// </summary>
+		public bool IsDeadline { get; set; } = false;
+
+		/// <summary>
+		/// The proof link.
+		/// </summary>
+		public Uri ProofImage { get; set; }
+
+		/// <summary>
+		/// The proof source.
+		/// </summary>
+		public Uri ProofSource { get; set; }
+
+		/// <summary>
+		/// The event title.
+		/// </summary>
+		public string Title { get; set; }
+	}
+}

--- a/src/CoinBot.Core/EventDto.cs
+++ b/src/CoinBot.Core/EventDto.cs
@@ -27,7 +27,7 @@ namespace CoinBot.Core
 		/// <summary>
 		/// If true, the <see cref="Date"/> is a deadline.
 		/// </summary>
-		public bool IsDeadline { get; set; } = false;
+		public bool CanOccurBefore { get; set; } = false;
 
 		/// <summary>
 		/// The proof link.

--- a/src/CoinBot.Core/EventManager.cs
+++ b/src/CoinBot.Core/EventManager.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace CoinBot.Core
+{
+	public class EventManager
+	{
+		/// <summary>
+		/// The <see cref="IEventClient"/>s.
+		/// </summary>
+		private readonly IEnumerable<IEventClient> _eventClients;
+
+		/// <summary>
+		/// The <see cref="IMemoryCache"/>.
+		/// </summary>
+		private readonly IMemoryCache _cache;
+
+		/// <summary>
+		/// Constructs an <see cref="EventManager"/>.
+		/// </summary>
+		/// <param name="eventClients">The <see cref="IEventClient"/>s.</param>
+		/// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+		/// <param name="logger">The <see cref="ILogger"/>.</param>
+		public EventManager(IEnumerable<IEventClient> eventClients, IMemoryCache cache, ILogger logger)
+		{
+			this._eventClients = eventClients ?? throw new ArgumentNullException(nameof(eventClients));
+			this._cache = cache ?? throw new ArgumentNullException(nameof(cache));
+		}
+
+		/// <summary>
+		/// Get events for the given <paramref name="currency"/>.
+		/// </summary>
+		/// <param name="currency">The <see cref="Currency"/>.</param>
+		/// <returns></returns>
+		public async Task<EventsDto> Get(Currency currency)
+		{
+			string cacheKey = $"events-{currency.Name}+{currency.Symbol}";
+			if (this._cache.TryGetValue(cacheKey, out EventsDto events))
+				return events;
+
+			var eventClient = this._eventClients.First();
+			events = await eventClient.GetEvents(currency);
+
+			using (var entry = this._cache.CreateEntry(cacheKey))
+			{
+				entry.SetAbsoluteExpiration(TimeSpan.FromMinutes(30));
+				entry.SetValue(events);
+			}
+
+			return events;
+		}
+	}
+}

--- a/src/CoinBot.Core/EventsDto.cs
+++ b/src/CoinBot.Core/EventsDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CoinBot.Core
+{
+	public sealed class EventsDto
+	{
+		/// <summary>
+		/// Last <see cref="DateTime"/> of the last update.
+		/// </summary>
+		public DateTime LastUpdated { get; set; }
+
+		/// <summary>
+		/// The <see cref="EventDto"/>s.
+		/// </summary>
+		public List<EventDto> Events { get; set; }
+	}
+}

--- a/src/CoinBot.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CoinBot.Core/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,11 @@ namespace CoinBot.Core.Extensions
 	public static class ServiceCollectionExtensions
 	{
 		/// <summary>
+		/// The <see cref="IConfiguration"/> section key of the <see cref="CoinMarketCalSettings"/>.
+		/// </summary>
+		private const string CoinMarketCalSettingsSection = "CoinMarketCal";
+
+		/// <summary>
 		/// The <see cref="IConfiguration"/> section key of the <see cref="MarketManagerSettings"/>.
 		/// </summary>
 		private const string MarketManagerSettingsSection = "MarketManager";
@@ -23,6 +28,7 @@ namespace CoinBot.Core.Extensions
 		{
 			return services
 				.Configure<MarketManagerSettings>(configuration.GetSection(MarketManagerSettingsSection))
+				.Configure<CoinMarketCalSettings>(configuration.GetSection(CoinMarketCalSettingsSection))
 				.AddSingleton<CurrencyManager>()
 				.AddSingleton<MarketManager>()
 				.AddSingleton<EventManager>();

--- a/src/CoinBot.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CoinBot.Core/Extensions/ServiceCollectionExtensions.cs
@@ -24,7 +24,8 @@ namespace CoinBot.Core.Extensions
 			return services
 				.Configure<MarketManagerSettings>(configuration.GetSection(MarketManagerSettingsSection))
 				.AddSingleton<CurrencyManager>()
-				.AddSingleton<MarketManager>();
+				.AddSingleton<MarketManager>()
+				.AddSingleton<EventManager>();
 		}
 	}
 }

--- a/src/CoinBot.Core/IEventClient.cs
+++ b/src/CoinBot.Core/IEventClient.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace CoinBot.Core
+{
+	public interface IEventClient
+	{
+		Task<EventsDto> GetEvents(Currency currency);
+	}
+}

--- a/src/CoinBot.Discord/Commands/CommandBase.cs
+++ b/src/CoinBot.Discord/Commands/CommandBase.cs
@@ -23,7 +23,7 @@ namespace CoinBot.Discord.Commands
 				builder.Timestamp = dateTime;
 				builder.Footer = new EmbedFooterBuilder
 				{
-					Text = "Prices updated"
+					Text = "Updated"
 				};
 			}
 		}

--- a/src/CoinBot.Discord/Commands/EventCommands.cs
+++ b/src/CoinBot.Discord/Commands/EventCommands.cs
@@ -45,8 +45,8 @@ namespace CoinBot.Discord.Commands
 						if (e.ProofImage != null)
 							eventDetails.AppendLine(this.GetEventFooter(e));
 						eventDetails.AppendLine($"```{e.Description}```");
-						string title = e.IsDeadline
-							? $"(deadline) {e.Date:dddd dd MMMM} - {e.Title}"
+						string title = e.CanOccurBefore
+							? $"(can occur before) {e.Date:dddd dd MMMM} - {e.Title}"
 							: $"{e.Date:dddd dd MMMM} - {e.Title}";
 						
 						builder.AddField(title, eventDetails);

--- a/src/CoinBot.Discord/Commands/EventCommands.cs
+++ b/src/CoinBot.Discord/Commands/EventCommands.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using CoinBot.Core;
+using CoinBot.Core.Extensions;
+using Discord;
+using Discord.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace CoinBot.Discord.Commands
+{
+	public class EventCommands : CommandBase
+	{
+		private readonly CurrencyManager _currencyManager;
+		private readonly EventManager _eventManager;
+		private readonly ILogger _logger;
+
+		public EventCommands(CurrencyManager currencyManager, EventManager eventManager, ILogger logger)
+		{
+			this._currencyManager = currencyManager ?? throw new ArgumentNullException(nameof(currencyManager));
+			this._eventManager = eventManager ?? throw new ArgumentNullException(nameof(eventManager));
+			this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		[Command("events")]
+		[Summary("get events for a coin, e.g. `!events FUN`.")]
+		public async Task Events([Remainder] [Summary("The input as a single coin symbol")]
+			string input)
+		{
+			using (this.Context.Channel.EnterTypingState())
+				try
+				{
+					var currency = this._currencyManager.Get(input);
+					var builder = new EmbedBuilder();
+					builder
+						.WithTitle($"{currency.GetTitle()} events:")
+						.WithThumbnailUrl(currency.ImageUrl);
+
+					var result = await this._eventManager.Get(currency);
+					foreach (var e in result.Events)
+					{
+						var eventDetails = new StringBuilder();
+						
+						if (e.ProofImage != null)
+							eventDetails.AppendLine(this.GetEventFooter(e));
+						eventDetails.AppendLine($"```{e.Description}```");
+						string title = e.IsDeadline
+							? $"(deadline) {e.Date:dddd dd MMMM} - {e.Title}"
+							: $"{e.Date:dddd dd MMMM} - {e.Title}";
+						
+						builder.AddField(title, eventDetails);
+					}
+
+					builder.AddField("More events", "Visit https://www.coinmarketcal.com for more events!");
+					AddFooter(builder, result.LastUpdated);
+					await this.ReplyAsync($"events for `{currency.Name}`:", false, builder.Build());
+				}
+				catch (Exception e)
+				{
+					this._logger.LogError(0, e, $"Something went wrong while processing the !events command with input '{input}'");
+					await this.ReplyAsync("oops, something went wrong, sorry!");
+				}
+		}
+
+		private string GetEventFooter(EventDto e)
+		{
+			List<string> parts = new List<string>();
+			if (e.ProofImage != null)
+				parts.Add($"[proof]({e.ProofImage})");
+
+			if (e.ProofSource != null)
+				parts.Add($"[source]({e.ProofSource})");
+
+			parts.Add($"Reliability: {e.Reliability}%");
+
+			string footer = string.Join(" | ", parts);
+			return footer;
+		}
+	}
+}

--- a/src/CoinBot.Discord/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CoinBot.Discord/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace CoinBot.Discord.Extensions
 					commandService.AddModuleAsync<HelpCommands>();
 					commandService.AddModuleAsync<PriceCommands>();
 					commandService.AddModuleAsync<MarketsCommands>();
+					commandService.AddModuleAsync<EventCommands>();
 					return commandService;
 				})
 				.AddSingleton<DiscordBot>();

--- a/src/CoinBot.sln
+++ b/src/CoinBot.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoinBot.Discord", "CoinBot.Discord\CoinBot.Discord.csproj", "{3E19CF74-9579-4D3B-B8C5-4DD3ED95330B}"
 EndProject

--- a/src/CoinBot/appsettings.json
+++ b/src/CoinBot/appsettings.json
@@ -4,5 +4,9 @@
   },
   "MarketManager": {
     "RefreshInterval": 2
+  },
+  "CoinMarketCal": {
+    "ClientId": "",
+    "ClientSecret": ""
   }
 }


### PR DESCRIPTION
I've added an EventManager with a CoinMarketCal implementation.

Using the CoinMarketCal API is free. Later, it might change depending on usage. I've got this first hand from the CoinMarketCal founder, Anthony.

For now it is a simple implementation. Because of the great amount of events and the amount of HTTP requests needed to update all events, I have chosen to just retrieve the events for a particular coin once they are requested. I did build in a cache of 30 minutes.

Anthony requested to mention the data source, coinmarketcal.com, so I've added that in the Discord response.

![image](https://user-images.githubusercontent.com/1898162/35121519-f86bf8f8-fc9b-11e7-8f22-a837161d84b3.png)
