### PR TITLE
Add market details from the HitBTC exchange

### DIFF
--- a/src/CoinBot.Clients/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CoinBot.Clients/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using CoinBot.Clients.Bittrex;
 using CoinBot.Clients.CoinMarketCap;
 using CoinBot.Clients.GateIo;
 using CoinBot.Clients.Gdax;
+using CoinBot.Clients.HitBtc;
 using CoinBot.Clients.Kraken;
 using CoinBot.Clients.Liqui;
 using CoinBot.Clients.Poloniex;
@@ -29,6 +30,7 @@ namespace CoinBot.Clients.Extensions
 				.AddSingleton<IMarketClient, BittrexClient>()
 				.AddSingleton<IMarketClient, GdaxClient>()
 				.AddSingleton<IMarketClient, GateIoClient>()
+				.AddSingleton<IMarketClient, HitBtcClient>()
 				.AddSingleton<IMarketClient, KrakenClient>()
 				.AddSingleton<IMarketClient, LiquiClient>()
 				.AddSingleton<IMarketClient, PoloniexClient>();

--- a/src/CoinBot.Clients/HitBtc/HitBtcClient.cs
+++ b/src/CoinBot.Clients/HitBtc/HitBtcClient.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using CoinBot.Core;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace CoinBot.Clients.HitBtc
+{
+	public class HitBtcClient : IMarketClient
+	{
+		/// <summary>
+		/// The <see cref="CurrencyManager"/>.
+		/// </summary>
+		private readonly CurrencyManager _currencyManager;
+
+		public string Name => "HitBtc";
+
+		/// <summary>
+		/// The <see cref="Uri"/> of the CoinMarketCap endpoint.
+		/// </summary>
+		private readonly Uri _endpoint = new Uri("https://api.hitbtc.com/api/2/public/", UriKind.Absolute);
+
+		/// <summary>
+		/// The <see cref="HttpClient"/>.
+		/// </summary>
+		private readonly HttpClient _httpClient;
+
+		/// <summary>
+		/// The <see cref="ILogger"/>.
+		/// </summary>
+		private readonly ILogger _logger;
+
+		/// <summary>
+		/// The <see cref="JsonSerializerSettings"/>.
+		/// </summary>
+		private readonly JsonSerializerSettings _serializerSettings;
+
+		public HitBtcClient(ILogger logger, CurrencyManager currencyManager)
+		{
+			this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this._currencyManager = currencyManager ?? throw new ArgumentNullException(nameof(currencyManager));
+
+			this._httpClient = new HttpClient
+			{
+				BaseAddress = this._endpoint
+			};
+
+			this._serializerSettings = new JsonSerializerSettings
+			{
+				Error = (sender, args) =>
+				{
+					var ex = args.ErrorContext.Error.GetBaseException();
+					this._logger.LogError(new EventId(args.ErrorContext.Error.HResult), ex, ex.Message);
+				}
+			};
+		}
+
+		/// <inheritdoc/>
+		public async Task<IReadOnlyCollection<MarketSummaryDto>> Get()
+		{
+			try
+			{
+				List<HitBtcTicker> tickers = await this.GetTicker();
+
+				return tickers.Select(t => new MarketSummaryDto
+				{
+					BaseCurrrency = this._currencyManager.Get(t.BaseCurrency),
+					MarketCurrency = this._currencyManager.Get(t.QuoteCurrency),
+					Market = "HitBTC",
+					Volume = t.Volume,
+					Last = t.Last,
+					LastUpdated = t.Timestamp,
+				}).ToList();
+			}
+			catch (Exception e)
+			{
+				this._logger.LogError(new EventId(e.HResult), e, e.Message);
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Get the tickers.
+		/// </summary>
+		/// <returns></returns>
+		private async Task<List<HitBtcTicker>> GetTicker()
+		{
+			List<HitBtcSymbol> symbols;
+			using (var response = await this._httpClient.GetAsync(new Uri("symbol", UriKind.Relative)))
+				symbols = JsonConvert.DeserializeObject<List<HitBtcSymbol>>(await response.Content.ReadAsStringAsync(), this._serializerSettings);
+
+			using (var response = await this._httpClient.GetAsync(new Uri("ticker", UriKind.Relative)))
+			{
+				List<HitBtcTicker> tickers = JsonConvert.DeserializeObject<List<HitBtcTicker>>(await response.Content.ReadAsStringAsync(), this._serializerSettings);
+				foreach (var ticker in tickers)
+				{
+					var symbol = symbols.FirstOrDefault(s => s.Id == ticker.Symbol);
+					if (symbol == null)
+						continue;
+
+					ticker.BaseCurrency = symbol.BaseCurrency;
+					ticker.QuoteCurrency = symbol.QuoteCurrency;
+				}
+				return tickers
+					.Where(t => !string.IsNullOrEmpty(t.BaseCurrency) && !string.IsNullOrEmpty(t.QuoteCurrency))
+					.ToList();
+			}
+		}
+	}
+}

--- a/src/CoinBot.Clients/HitBtc/HitBtcSymbol.cs
+++ b/src/CoinBot.Clients/HitBtc/HitBtcSymbol.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+
+namespace CoinBot.Clients.HitBtc
+{
+	[JsonObject]
+	internal sealed class HitBtcSymbol
+	{
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
+		[JsonProperty("baseCurrency")]
+		public string BaseCurrency { get; set; }
+
+		[JsonProperty("quoteCurrency")]
+		public string QuoteCurrency { get; set; }
+
+		[JsonProperty("quantityIncrement")]
+		public string QuantityIncrement { get; set; }
+
+		[JsonProperty("tickSize")]
+		public string TickSize { get; set; }
+
+		[JsonProperty("takeLiquidityRate")]
+		public string TakeLiquidityRate { get; set; }
+
+		[JsonProperty("provideLiquidityRate")]
+		public string ProvideLiquidityRate { get; set; }
+
+		[JsonProperty("feeCurrency")]
+		public string FeeCurrency { get; set; }
+	}
+}

--- a/src/CoinBot.Clients/HitBtc/HitBtcTicker.cs
+++ b/src/CoinBot.Clients/HitBtc/HitBtcTicker.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace CoinBot.Clients.HitBtc
+{
+	[JsonObject]
+	internal sealed class HitBtcTicker
+	{
+		[JsonProperty("ask")]
+		public decimal? Ask { get; set; }
+
+		[JsonProperty("bid")]
+		public decimal? Bid { get; set; }
+
+		[JsonProperty("last")]
+		public decimal? Last { get; set; }
+
+		[JsonProperty("open")]
+		public decimal? Open { get; set; }
+
+		[JsonProperty("low")]
+		public decimal? Low { get; set; }
+
+		[JsonProperty("high")]
+		public decimal? High { get; set; }
+
+		[JsonProperty("volume")]
+		public decimal? Volume { get; set; }
+
+		[JsonProperty("volumeQuote")]
+		public decimal? VolumeQuote { get; set; }
+
+		[JsonProperty("timestamp")]
+		public DateTime? Timestamp { get; set; }
+
+		[JsonProperty("symbol")]
+		public string Symbol { get; set; }
+
+		public string BaseCurrency { get; set; }
+
+		public string QuoteCurrency { get; set; }
+	}
+}


### PR DESCRIPTION
This change will add market details from the HitBTC exchange to the `!markets` command.